### PR TITLE
Remove `null_ls.config...`

### DIFF
--- a/lua/jet.lua
+++ b/lua/jet.lua
@@ -43,9 +43,9 @@ function M.setup(opts)
   }
 
   null_ls.register(jet_julia)
-  null_ls.config({
-    sources = { jet_julia },
-  })
+  -- null_ls.config({
+  --   sources = { jet_julia },
+  -- })
 
   if setup_lspconfig then
     require("lspconfig")["null-ls"].setup({})

--- a/lua/jet.lua
+++ b/lua/jet.lua
@@ -43,9 +43,6 @@ function M.setup(opts)
   }
 
   null_ls.register(jet_julia)
-  -- null_ls.config({
-  --   sources = { jet_julia },
-  -- })
 
   if setup_lspconfig then
     require("lspconfig")["null-ls"].setup({})


### PR DESCRIPTION
null_ls seems to have changed their API, accessing the `config` table now creates an error, and just using `register` is sufficient to get JET running!